### PR TITLE
test data gen for linkedin  heatmap POC

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,7 @@ var elasticData6 = require('./elastic_data6');
 var influxData = require('./influx_data');
 var influxData08 = require('./influx_data08');
 var promData = require('./prom_data');
+var promDataLinkedIn = require('./prom_data_linkedin_heatmap');
 var grafanaLive = require('./grafana_live');
 var sqlData = require('./sql_data');
 var verticaData = require('./vertica_data');
@@ -31,6 +32,8 @@ program
   .option('--elasticsearch', 'Live feed data to elasticsearch')
   .option('--elasticsearch6', 'Live feed data to elasticsearch 6.x')
   .option('--prom', 'Live feed data to prometheus')
+  .option('--promLinkedinHeatmap', 'Live feed data to prometheus')
+  .option('--linkedinHeatmapLabelsNum <linkedinHeatmapLabelsNum>', 'Number of labels in one dimension')
   .option('--mysql', 'Live feed data to mysql')
   .option('--postgres', 'Live feed data to postgresql')
   .option('--mssql', 'Live feed data to mssql')
@@ -61,6 +64,10 @@ if (program.opentsdb) {
 
 if (program.prom) {
   promData.live();
+}
+
+if (program.promLinkedinHeatmap) {
+  promDataLinkedIn.live(program.linkedinHeatmapLabelsNum);
 }
 
 if (program.grafanaLive) {

--- a/src/app.js
+++ b/src/app.js
@@ -34,6 +34,7 @@ program
   .option('--prom', 'Live feed data to prometheus')
   .option('--promLinkedinHeatmap', 'Live feed data to prometheus')
   .option('--linkedinHeatmapLabelsNum <linkedinHeatmapLabelsNum>', 'Number of labels in one dimension')
+  .option('--linkedinMissingLinkRatio <linkedinMissingLinkRatio>', 'How many links between switches are not exist')
   .option('--mysql', 'Live feed data to mysql')
   .option('--postgres', 'Live feed data to postgresql')
   .option('--mssql', 'Live feed data to mssql')
@@ -67,7 +68,7 @@ if (program.prom) {
 }
 
 if (program.promLinkedinHeatmap) {
-  promDataLinkedIn.live(program.linkedinHeatmapLabelsNum);
+  promDataLinkedIn.live(program.linkedinHeatmapLabelsNum, program.linkedinMissingLinkRatio);
 }
 
 if (program.grafanaLive) {

--- a/src/prom_data_linkedin_heatmap.js
+++ b/src/prom_data_linkedin_heatmap.js
@@ -1,0 +1,68 @@
+var _ = require('lodash');
+var Prometheus = require("prometheus-client");
+
+function getLabels(base, number, missingLinkRatio) {
+  console.log(`creating ${number} labels with base name '${base}' and missingLinkRatio ${missingLinkRatio}`);
+  const missingLinks = {};
+  const labels = [];
+  for (let i = 0; i < number; i++) {
+    const src_label = `${base}_${i}`;
+    for (let j = 0; j < number; j++) {
+      if (i !== j && i < j && Math.random() < missingLinkRatio) {
+        // console.log('missing', i, j);
+        if (missingLinks[j]) {
+          missingLinks[j].push(i)
+        } else {
+          missingLinks[j] = [i];
+        }
+        continue;
+      }
+
+      const dst_label = `${base}_${j}`;
+      if (i !== j && !(missingLinks[i] && missingLinks[i].includes(j))) {
+        const label = { src: src_label, dst: dst_label };
+        // console.log(label);
+        labels.push(label);
+      }
+    }
+  }
+  // console.log(missingLinks);
+  return labels;
+}
+
+function live(labelsNum) {
+  var client = new Prometheus();
+  const test_label_sets = getLabels('switch', labelsNum || 100, 0.3);
+  console.log('Starting to feed data');
+
+  var packets = client.newCounter({
+    namespace: "counters",
+    name: "packets",
+    help: "Counters"
+  });
+
+  var latency = client.newCounter({
+    namespace: "counters",
+    name: "latency",
+    help: "Counters"
+  });
+
+
+  client.listen(9095);
+  var data = {};
+
+  function randomWalk(labels, variation) {
+    packets.increment(labels, 1000 + (Math.random() * 1000));
+    latency.increment(labels, Math.abs((Math.random() * variation) - (variation / 2)));
+  }
+
+  setInterval(function() {
+    test_label_sets.forEach(function(label_set) {
+      randomWalk(label_set, 2);
+    });
+  }, 30000);
+}
+
+module.exports = {
+  live: live
+};

--- a/src/prom_data_linkedin_heatmap.js
+++ b/src/prom_data_linkedin_heatmap.js
@@ -30,9 +30,9 @@ function getLabels(base, number, missingLinkRatio) {
   return labels;
 }
 
-function live(labelsNum) {
+function live(labelsNum, missingLinkRatio) {
   var client = new Prometheus();
-  const test_label_sets = getLabels('switch', labelsNum || 100, 0.3);
+  const test_label_sets = getLabels('switch', labelsNum || 100, missingLinkRatio || 0.3);
   console.log('Starting to feed data');
 
   var packets = client.newCounter({

--- a/src/start.sh
+++ b/src/start.sh
@@ -10,15 +10,30 @@ echo $hostip
 : "${FD_GRAPHITE_VERSION:=0.9}"
 : "${FD_NR_API_KEY:=""}"
 : "${FD_NR_ACCOUNT_ID:=""}"
+: "${FD_HEATMAP_LABELS_NUM:=""}"
+: "${FD_NODE_MEMORY_SIZE:=""}"
 
 echo $FD_DATASOURCE
 echo $FD_PORT
 echo $FD_SERVER
 echo $FD_GRAPHITE_VERSION
 
+if [ "$FD_DATASOURCE" = "promLinkedinHeatmap" ]; then
+  echo "FD_HEATMAP_LABELS_NUM: $FD_HEATMAP_LABELS_NUM"
+fi
+
 params="--${FD_DATASOURCE} --server ${FD_SERVER} --port ${FD_PORT} --live --import --days 3 --graphite-version ${FD_GRAPHITE_VERSION}"
 if [ "$FD_DATASOURCE" = "newrelic" ]; then
   params="$params --apiKey ${FD_NR_API_KEY} --accountId ${FD_NR_ACCOUNT_ID}"
 fi
+if [ "$FD_DATASOURCE" = "promLinkedinHeatmap" ]; then
+  params="$params --linkedinHeatmapLabelsNum ${FD_HEATMAP_LABELS_NUM}"
+fi
 echo $params
-node app.js $params
+
+node_params=""
+if [ ! -z "${FD_NODE_MEMORY_SIZE}" ]; then
+  node_params="--max-old-space-size=${FD_NODE_MEMORY_SIZE}"
+  echo $node_params
+fi
+node $node_params app.js $params

--- a/src/start.sh
+++ b/src/start.sh
@@ -11,6 +11,7 @@ echo $hostip
 : "${FD_NR_API_KEY:=""}"
 : "${FD_NR_ACCOUNT_ID:=""}"
 : "${FD_HEATMAP_LABELS_NUM:=""}"
+: "${FD_HEATMAP_MISSING_LINK_RATIO:=""}"
 : "${FD_NODE_MEMORY_SIZE:=""}"
 
 echo $FD_DATASOURCE
@@ -28,6 +29,9 @@ if [ "$FD_DATASOURCE" = "newrelic" ]; then
 fi
 if [ "$FD_DATASOURCE" = "promLinkedinHeatmap" ]; then
   params="$params --linkedinHeatmapLabelsNum ${FD_HEATMAP_LABELS_NUM}"
+fi
+if [ ! -z "${FD_HEATMAP_MISSING_LINK_RATIO}" ]; then
+  params="$params --linkedinMissingLinkRatio ${FD_HEATMAP_MISSING_LINK_RATIO}"
 fi
 echo $params
 


### PR DESCRIPTION
This test data gen generates series with combination of labels `switch_1, switch_2, switch_<FD_HEATMAP_LABELS_NUM>`, so result number of unique series will be `FD_HEATMAP_LABELS_NUM ^ 2`. In this example it will be `500 x 500 = 250 000`. `FD_HEATMAP_MISSING_LINK_RATIO` param can be used to limit number of series (`0.8` means only 20% of labels will generate data). Use `FD_NODE_MEMORY_SIZE` to increase node memory limit.

```yaml
fake-prometheus-linkedin-data:
    image: grafana/fake-data-gen
    ports:
      - "9095:9095"
    environment:
      FD_DATASOURCE: promLinkedinHeatmap
      FD_PORT: 9095
      FD_HEATMAP_LABELS_NUM: 500
      FD_HEATMAP_MISSING_LINK_RATIO: 0.8
      FD_NODE_MEMORY_SIZE: 4096      
```

Prometheus config:
```yaml
scrape_configs:
  - job_name: 'prometheus_linkedin_data'
    scrape_interval: 60s
    scrape_timeout: 30s
    static_configs:
      - targets: ['127.0.0.1:9095']
```