### PR TITLE
Add template for logs

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -1,5 +1,5 @@
 #/bin/sh
-VERSION=v7
+VERSION=v8
 
 docker build -t grafana/fake-data-gen:latest -t grafana/fake-data-gen:$VERSION --no-cache=true .
 

--- a/src/elastic_data.js
+++ b/src/elastic_data.js
@@ -31,6 +31,19 @@ var ES_METRICS_TEMPLATE = {
   }
 };
 
+var ES_LOGS_TEMPLATE = {
+  "template" : "logs-*",
+  "settings" : { "number_of_shards" : 1, "number_of_replicas": 0 },
+  "mappings" : {
+    "logs" : {
+      "_source": {"enabled": true},
+      "properties": {
+        "@timestamp": {"type": 'date', "format": "epoch_millis"},
+      }
+    }
+  }
+};
+
 function liveFeedToLogstash(program) {
   console.log('Starting Elasticsearch Data Sender');
 
@@ -65,8 +78,14 @@ function liveFeedToLogstash(program) {
       if (err) {
         console.log('template mapping error:', err);
       } else {
-        console.log('template created');
-        feedDataCallback();
+        client.put('/_template/logs', ES_LOGS_TEMPLATE, function(err, req, res, obj) {
+          if (err) {
+            console.log('template mapping error:', err);
+          } else {
+            console.log('templates created');
+            feedDataCallback();
+          }
+        });
       }
     });
   }
@@ -179,7 +198,7 @@ function liveFeedToLogstash(program) {
 
     var writeLogEntryID = setInterval(function() {
       writeLogEntry(recoveryCallback);
-    }, Math.random() * 900000);
+    }, Math.random() * 50000);
 
     var recoveryCallback = _.once(recoveryAction);
     function recoveryAction() {

--- a/src/elastic_data6.js
+++ b/src/elastic_data6.js
@@ -28,6 +28,19 @@ var ES_METRICS_TEMPLATE = {
   }
 };
 
+var ES_LOGS_TEMPLATE = {
+  "template" : "logs-*",
+  "settings" : { "number_of_shards" : 1, "number_of_replicas": 0 },
+  "mappings" : {
+    "log" : {
+      "_source": {"enabled": true},
+      "properties": {
+        "@timestamp": {"type": 'date', "format": "epoch_millis"},
+      }
+    }
+  }
+};
+
 function liveFeedToLogstash(program) {
   console.log('Starting Elasticsearch Data Sender');
 
@@ -62,8 +75,14 @@ function liveFeedToLogstash(program) {
       if (err) {
         console.log('template mapping error:', err);
       } else {
-        console.log('template created');
-        feedDataCallback();
+        client.put('/_template/logs', ES_LOGS_TEMPLATE, function(err, req, res, obj) {
+          if (err) {
+            console.log('template mapping error:', err);
+          } else {
+            console.log('templates created');
+            feedDataCallback();
+          }
+        });
       }
     });
   }

--- a/src/elastic_data7.js
+++ b/src/elastic_data7.js
@@ -26,6 +26,17 @@ var ES_METRICS_TEMPLATE = {
   }
 };
 
+var ES_LOGS_TEMPLATE = {
+    "template" : "logs-*",
+    "settings" : { "number_of_shards" : 1, "number_of_replicas": 0 },
+    "mappings" : {
+        "_source" : { "enabled" : true },
+        "properties": {
+            "@timestamp": { "type": 'date', "format": "epoch_millis" },
+        }
+    }
+};
+
 function liveFeedToLogstash(program) {
   console.log('Starting Elasticsearch Data Sender');
 
@@ -60,8 +71,14 @@ function liveFeedToLogstash(program) {
       if (err) {
         console.log('template mapping error:', err);
       } else {
-        console.log('template created');
-        feedDataCallback();
+        client.put('/_template/logs', ES_LOGS_TEMPLATE, function(err, req, res, obj) {
+          if (err) {
+            console.log('template mapping error:', err);
+          } else {
+            console.log('templates created');
+            feedDataCallback();
+          }
+        });
       }
     });
   }


### PR DESCRIPTION
Without it the `@timestamp` field would not be recognised as time field and would throw error when trying to query it as such.