### PR TITLE
chore(ci): migrate to docker-build-push-image action

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -21,12 +21,13 @@ jobs:
           persist-credentials: false
 
       - id: push-to-dockerhub
-        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@402975d84dd3fac9ba690f994f412d0ee2f51cf4 # build-push-to-dockerhub-v0.1.1
+        uses: grafana/shared-workflows/actions/docker-build-push-image@21ae57f82e5256e5a418406388926d4ba24bccf2 # docker-build-push-image/v0.3.2
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          repository: grafana/fake-data-gen
+          dockerhub-repository: grafana/fake-data-gen
+          registries: dockerhub
           tags: |-
             ${{ github.sha }}
             latest


### PR DESCRIPTION
Migrates from the deprecated `build-push-to-dockerhub` action to the unified [`docker-build-push-image`](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image) action.

## What This Changes

- Updated action reference from `build-push-to-dockerhub` to `docker-build-push-image@v0.3.2`
- Renamed `repository` input to `dockerhub-repository`
- Added `registries: dockerhub` input

## References

- [docker-build-push-image docs](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image)
- [Migration guide](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image#migrating-from-push-to-gar-docker)
- [Repo migration tracking issue](https://github.com/grafana/deployment_tools/issues/390404)