### PR TITLE
fix: correct lodash 4 template usage and guard against double-tagging graphite 1.1 metrics

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -165,10 +165,10 @@ function import_data(graphiteVersion) {
     var key;
     if (graphiteVersion === '1.1') {
       // Convert to tagged format
-      key = _.template(meta.pattern, { target: "" }).replace("..", ".");
+      key = _.template(meta.pattern)({ target: "" }).replace("..", ".");
       key += ";target=" + series.target;
     } else {
-      key = _.template(meta.pattern, { target: series.target });
+      key = _.template(meta.pattern)({ target: series.target });
     }
     var index = find_current_index(series.datapoints);
     var currentDate = new Date();
@@ -309,10 +309,10 @@ function live_data(graphiteVersion) {
     var key;
     if (graphiteVersion === '1.1') {
       // Convert to tagged format
-      key = _.template(meta.pattern, { target: "" }).replace("..", ".");
+      key = _.template(meta.pattern)({ target: "" }).replace("..", ".");
       key += ";target=" + series.target;
     } else {
-      key = _.template(meta.pattern, { target: series.target });
+      key = _.template(meta.pattern)({ target: series.target });
     }
 
     metrics[key] = { points: series.datapoints };

--- a/src/app.js
+++ b/src/app.js
@@ -163,8 +163,8 @@ function import_data(graphiteVersion) {
     var now = new Date();
 
     var key;
-    if (graphiteVersion === '1.1') {
-      // Convert to tagged format
+    if (graphiteVersion === '1.1' && meta.pattern.indexOf(';') === -1) {
+      // Convert dotted-path metric to tagged format
       key = _.template(meta.pattern)({ target: "" }).replace("..", ".");
       key += ";target=" + series.target;
     } else {
@@ -307,8 +307,8 @@ function live_data(graphiteVersion) {
 
   function live_feed(meta, series) {
     var key;
-    if (graphiteVersion === '1.1') {
-      // Convert to tagged format
+    if (graphiteVersion === '1.1' && meta.pattern.indexOf(';') === -1) {
+      // Convert dotted-path metric to tagged format
       key = _.template(meta.pattern)({ target: "" }).replace("..", ".");
       key += ";target=" + series.target;
     } else {


### PR DESCRIPTION
Two related bug fixes in src/app.js for the Graphite 1.1 tagged-metric path:

1. Use the lodash 4 _.template API (the repo pins "lodash": "^4.0.0", but the code still called the lodash 3 signature).
2. Skip dotted-path→tagged conversion for patterns that are already tagged, preventing malformed keys.